### PR TITLE
【Fixed】`rails g`コマンドの際にassetsファイル、helperが作成されないように改善

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,6 +24,7 @@
             <% end %>
           </div>
         </div>
+      </div>
       </nav>
       <% flash.each do |key, value| %>
       <%= content_tag(:div, value, class: "#{key}") %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,11 @@ module PhotoShareApp
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.1
+    
+    config.generators do |g|
+      g.assets     false
+      g.helper     false
+    end
 
     # Configuration for the application, engines, and railties goes here.
     #


### PR DESCRIPTION
#1 

config/application.rbに、以下を追加。
```
config.generators do |g|
      g.assets     false
      g.helper     false
    end
```